### PR TITLE
init gtklock module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,8 @@
         homeManagerModules = {
           xplr = ./modules/extra/shared/home-manager/xplr;
 
+          gtklock = ./modules/extra/shared/home-manager/gtklock;
+
           # again, we do not want to provide a default module
           default = null;
         };

--- a/modules/extra/shared/home-manager/gtklock/default.nix
+++ b/modules/extra/shared/home-manager/gtklock/default.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with builtins; let
+  cfg = config.programs.gtklock;
+
+  inherit (lib) types mkIf mkOption mkEnableOption mkPackageOptionMD mdDoc literalExpression optionals;
+  inherit (lib.generators) toINI;
+
+  baseConfig = ''
+    [main]
+    gtk-theme=${cfg.config.gtk-theme or ""}
+    style=${cfg.config.style or ""}
+    modules=${concatStringsSep "," cfg.config.modules or ""}
+  '';
+
+  finalConfig = baseConfig + optionals (cfg.extraConfig != null) (toINI {} cfg.extraConfig);
+in {
+  meta.maintainers = [maintainers.NotAShelf];
+  options.programs.gtklock = {
+    enable = mkEnableOption "GTK-based lockscreen for Wayland" // {default = true;};
+    package = mkPackageOptionMD pkgs "gtklock" {};
+
+    config = {
+      gtk-theme = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = mdDoc ''
+          GTK theme to use for gtklock.
+        '';
+        example = "Adwaita-dark";
+      };
+
+      style = mkOption {
+        type = with types; nullOr (oneOf [str path]);
+        default = null;
+        description = mdDoc ''
+          The css file to be used for gtklock.
+        '';
+        example = literalExpression ''
+          pkgs.writeText "gtklock-style.css" '''
+            window {
+              background-size: cover;
+              background-repeat: no-repeat;
+              background-position: center;
+            }
+          '''
+        '';
+      };
+
+      modules = mkOption {
+        type = with types; nullOr (listOf (either package str));
+        default = null;
+        description = mdDoc ''
+          A list of gtklock modulesto use. Can either be packages, absolute paths, or strings.
+        '';
+        example = literalExpression ''
+          ["${pkgs.gtklock-powerbar-module.outPath}/lib/gtklock/powerbar-module.so"];
+        '';
+      };
+    };
+
+    extraConfig = mkOption {
+      type = with types; nullOr attrs;
+      default = {
+        countdown = {
+          countdown-position = "top-right";
+          justify = "right";
+          countdown = 20;
+        };
+      };
+      description = mdDoc ''
+        Extra configuration to append to gtklock configuration file.
+        Mostly used for appending module configurations.
+      '';
+      example = literalExpression ''
+        countdown = {
+          countdown-position = "top-right";
+          justify = "right";
+          countdown = 20;
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    xdg.configFile."gtklock/config.ini".source = pkgs.writeText "gtklock-config.ini" finalConfig;
+  };
+}


### PR DESCRIPTION
There currently is not a home-manager module for gtklock. Until I can get one merged into home-manager, I shall provide it from my own flake.