### PR TITLE
services/nginx: enable nginxQuic

### DIFF
--- a/modules/core/roles/server/system/services/nextcloud.nix
+++ b/modules/core/roles/server/system/services/nextcloud.nix
@@ -92,7 +92,7 @@ in {
         };
       };
 
-      nginx.virtualHosts."cloud.notashelf.dev" = lib.sslTemplate;
+      nginx.virtualHosts."cloud.notashelf.dev" = {http3.enable = true;} // lib.sslTemplate;
     };
 
     systemd.services = {

--- a/modules/core/roles/server/system/services/nginx.nix
+++ b/modules/core/roles/server/system/services/nginx.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf;
+  inherit (lib) mkIf mkDefault;
 
   sys = config.modules.system;
   cfg = sys.services;
@@ -17,38 +17,51 @@ in {
       };
     };
 
-    services.nginx = {
-      enable = true;
-      recommendedTlsSettings = true;
-      recommendedOptimisation = true;
-      recommendedGzipSettings = true;
-      recommendedProxySettings = true;
-      recommendedZstdSettings = true;
+    services = {
+      nginx = {
+        enable = true;
+        package = pkgs.nginxQuic;
+        recommendedTlsSettings = true;
+        recommendedBrotliSettings = true;
+        recommendedOptimisation = true;
+        recommendedGzipSettings = true;
+        recommendedProxySettings = true;
+        recommendedZstdSettings = true;
+        clientMaxBodySize = mkDefault "512m";
+        serverNamesHashBucketSize = 1024;
+        appendHttpConfig = ''
+          proxy_headers_hash_max_size 1024;
+          proxy_headers_hash_bucket_size 256;
+        '';
 
-      # FIXME: this normally makes the /nginx_status endpoint availabe, but nextcloud hijacks it and returns a SSL error
-      # we need it for prometheus, so it would be *great* to figure out a solution
-      statusPage = false;
+        # lets be more picky on our ciphers and protocols
+        sslCiphers = "EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
+        sslProtocols = "TLSv1.3 TLSv1.2";
 
-      # lets be more picky on our ciphers and protocols
-      sslCiphers = "EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
-      sslProtocols = "TLSv1.3 TLSv1.2";
+        commonHttpConfig = ''
+          add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
 
-      commonHttpConfig = ''
-        #real_ip_header CF-Connecting-IP;
-        add_header 'Referrer-Policy' 'origin-when-cross-origin';
-        add_header X-Frame-Options DENY;
-        add_header X-Content-Type-Options nosniff;
-      '';
+          access_log  /var/log/nginx/access.log combined;
+          error_log   /var/log/nginx/error.log warn;
+        '';
 
-      virtualHosts = {
-        "${config.networking.domain}" = {
-          default = true;
-          serverAliases = ["www.${config.networking.domain}"];
-          extraConfig = ''
-            access_log /var/log/nginx/access.log;
-            error_log /var/log/nginx/error.log;
-          '';
+        # FIXME: this normally makes the /nginx_status endpoint availabe, but nextcloud hijacks it and returns a SSL error
+        # we need it for prometheus, so it would be *great* to figure out a solution
+        statusPage = true;
+
+        virtualHosts = {
+          "${config.networking.domain}" = {
+            default = true;
+            serverAliases = ["www.${config.networking.domain}"];
+          };
         };
+      };
+
+      logrotate.settings.nginx = {
+        enable = true;
+        minsize = "50M";
+        rotate = "4"; # 4 files of 50mb each
+        compress = "";
       };
     };
   };


### PR DESCRIPTION
Enable quic support in the nginx service, and tweak nginx http configuration.

Also see:

- https://www.nginx.com/resources/glossary/quic-http3/
- https://datatracker.ietf.org/doc/html/rfc9000
- https://nginx.org/en/docs/http/ngx_http_v3_module.html

Most services seem to support quick ootb. Nextcloud needed `http3.enable` to work.
