### PR TITLE
hosts/enyo: provide local kernel patches

### DIFF
--- a/hosts/enyo/default.nix
+++ b/hosts/enyo/default.nix
@@ -4,6 +4,7 @@
     ./fs
 
     ./btrfs.nix
+    ./kernel.nix
     ./networking.nix
     ./system.nix
     ./wireguard.nix # TODO: abstract

--- a/hosts/enyo/kernel.nix
+++ b/hosts/enyo/kernel.nix
@@ -1,0 +1,46 @@
+{lib, ...}: let
+  inherit (lib.kernel) yes no;
+  inherit (lib.attrsets) mapAttrs;
+  inherit (lib.modules) mkForce;
+in {
+  boot.kernelPatches = [
+    {
+      # enable lockdown LSM
+      name = "kernel-lockdown";
+      patch = null;
+      extraStructuredConfig = mapAttrs (_: mkForce) {
+        SECURITY_LOCKDOWN_LSM = yes;
+        MODULE_SIG = yes;
+      };
+    }
+    {
+      # recompile with AMD platform specific optimizations
+      name = "AMD Patches";
+      patch = null; # no patch is needed, just apply the options
+      extraStructuredConfig = mapAttrs (_: mkForce) {
+        # enable compiler optimizations for AMD
+        MNATIVE_AMD = yes;
+        X86_USE_PPRO_CHECKSUM = yes;
+
+        X86_EXTENDED_PLATFORM = no; # disable support for other x86 platforms
+        X86_MCE_INTEL = no; # disable support for intel mce
+
+        # Multigen LRU
+        LRU_GEN = yes;
+        LRU_GEN_ENABLED = yes;
+
+        # Optimized for performance
+        # FIXME: this is already set for the xanmod kernel
+        # so it should be set if and only if the kernel package
+        # is not xanmod under sys.boot
+        # CC_OPTIMIZE_FOR_PERFORMANCE_O3 = yes;
+      };
+
+      # enable only support for upto 32 CPU threads in the kernel
+      # this host has 16 cores and 32 threads
+      extraConfig = ''
+        NR_CPUS 32
+      '';
+    }
+  ];
+}

--- a/hosts/enyo/modules/system.nix
+++ b/hosts/enyo/modules/system.nix
@@ -11,7 +11,7 @@
       enableKernelTweaks = true;
       initrd.enableTweaks = true;
       loadRecommendedModules = true;
-      tmpOnTmpfs = true;
+      tmpOnTmpfs = false;
       plymouth = {
         enable = true;
         withThemes = false;

--- a/modules/options/system/boot.nix
+++ b/modules/options/system/boot.nix
@@ -13,7 +13,14 @@ in {
     enableKernelTweaks = mkEnableOption "security and performance related kernel parameters";
     recommendedLoaderConfig = mkEnableOption "tweaks for common bootloader configs per my liking";
     loadRecommendedModules = mkEnableOption "kernel modules that accommodate for most use cases";
-    tmpOnTmpfs = mkEnableOption "`/tmp` living on tmpfs. false means it will be cleared manually on each reboot";
+    tmpOnTmpfs =
+      mkEnableOption ''
+        `/tmp` living on tmpfs. false means it will be cleared manually on each reboot
+
+        This option defaults to `true` if the host provides patches to the kernel package in
+        `boot.kernelPatches`
+      ''
+      // {default = config.boot.kernelPatches == [];};
 
     secureBoot = mkEnableOption ''
       secure-boot with the necessary packages. Requires systemd-boot to be disabled


### PR DESCRIPTION
Provide a set of kernel configuration lines for `hosts/enyo`. Contains optimizations targeting AMD CPUs and the lockdown feature that was missing from XanMod.